### PR TITLE
Persistent auth

### DIFF
--- a/src/components/AuthContext.tsx
+++ b/src/components/AuthContext.tsx
@@ -24,20 +24,28 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = authService.getCurrentUser();
-    if (token) {
-      // Here you could verify the token and get user info
-      setLoading(false);
-    } else {
-      setLoading(false);
-    }
-  }, []);
+    (async () => {
+      const token = authService.getCurrentUser();
+      if (token && !user) {
+        const user = await authService.checkCurrentUserToken(token);
+        if (user) {
+          setUser(user);
+        } else {
+          logout();
+        }
+        setLoading(false);
+      } else {
+        setLoading(false);
+      }
+    })();
+  }, [user]);
 
   const login = async (username: string, password: string) => {
     try {
       const response = await authService.login({ username, password });
       setUser(response);
     } catch (error) {
+      console.log(error);
       throw error;
     }
   };
@@ -55,6 +63,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       });
       setUser(response);
     } catch (error) {
+      console.log(error);
       throw error;
     }
   };

--- a/src/lib/auth.service.ts
+++ b/src/lib/auth.service.ts
@@ -1,7 +1,7 @@
-import axios from 'axios';
-import Cookies from 'js-cookie';
+import axios from "axios";
+import Cookies from "js-cookie";
 
-const API_URL = 'http://localhost:8080/api/auth';
+const API_URL = "http://localhost:8080/api/auth";
 
 export interface LoginRequest {
   username: string;
@@ -25,12 +25,12 @@ class AuthService {
     try {
       const response = await axios.post(`${API_URL}/login`, data);
       if (response.data.token) {
-        Cookies.set('token', response.data.token, { expires: 1 });
+        Cookies.set("token", response.data.token, { expires: 1 });
       }
       return response.data;
     } catch (error: any) {
       if (error.response) {
-        throw new Error(error.response.data || 'Login failed');
+        throw new Error(error.response.data || "Login failed");
       }
       throw error;
     }
@@ -38,28 +38,51 @@ class AuthService {
 
   async register(data: RegisterRequest): Promise<AuthResponse> {
     try {
-      console.log('Sending registration data:', data);
+      console.log("Sending registration data:", data);
       const response = await axios.post(`${API_URL}/registerUser`, data);
-      console.log('Registration response:', response.data);
+      console.log("Registration response:", response.data);
       if (response.data.token) {
-        Cookies.set('token', response.data.token, { expires: 1 });
+        Cookies.set("token", response.data.token, { expires: 1 });
       }
       return response.data;
     } catch (error: any) {
-      console.error('Registration error:', error.response?.data || error.message);
+      console.error(
+        "Registration error:",
+        error.response?.data || error.message
+      );
       if (error.response) {
-        throw new Error(error.response.data || 'Registration failed');
+        throw new Error(error.response.data || "Registration failed");
       }
       throw error;
     }
   }
 
   logout(): void {
-    Cookies.remove('token');
+    Cookies.remove("token");
   }
 
   getCurrentUser(): string | undefined {
-    return Cookies.get('token');
+    return Cookies.get("token");
+  }
+
+  async checkCurrentUserToken(token: string): Promise<AuthResponse | null> {
+    try {
+      const response = await axios.get(`${API_URL}/checkToken`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      const user = response.data;
+      return {
+        token,
+        type: "Bearer",
+        username: user.username,
+      };
+    } catch (error) {
+      console.error("Token check failed", error);
+      return null;
+    }
   }
 
   isAuthenticated(): boolean {
@@ -67,4 +90,4 @@ class AuthService {
   }
 }
 
-export default new AuthService(); 
+export default new AuthService();


### PR DESCRIPTION
- pr on backend has to be merged in order for this to work
- client will now call /checkToken endpoint on the backend when token is saved in cookies, then remove it if backend returns invalid or authenticate if backend returns ok

this pr closes #11 